### PR TITLE
Making the copyright year dynamic #115

### DIFF
--- a/src/componenets/Footer/Footer.jsx
+++ b/src/componenets/Footer/Footer.jsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import Logo from "../Logo";
 
 function Footer() {
+  const currentYear = new Date().getFullYear();
   return (
     <footer className="custom-theme w-full bottom-0 py-10 bg-gray-300 border-t-1 border-t-black">
       <div className="z-10 mx-auto px-4">
@@ -14,7 +15,7 @@ function Footer() {
               </div>
               <div>
                 <p className="text-sm text-gray-600">
-                  &copy; Copyright 2023. All Rights Reserved by DevUI.
+                  &copy; Copyright {currentYear}. All Rights Reserved by DevUI.
                 </p>
               </div>
             </div>


### PR DESCRIPTION
Resolves #115 

**Previous :**
<img width="433" alt="Screenshot 2024-10-14 at 8 29 18 PM" src="https://github.com/user-attachments/assets/d2f2552d-76ea-4158-8d8b-26798f8e1a65">
**Now : **

<img width="396" alt="Screenshot 2024-10-14 at 8 34 36 PM" src="https://github.com/user-attachments/assets/9d5ad4d5-4c2f-4ad9-9d1d-d76c27ca361f">

Earlier the copyright year was hardcoded to be 2023, now it is dynamic and displays the current year automatically. We don't need to change the year manually when the new year comes. 

Kindly add the hacktober-fest accepted label to this issue as well