### PR TITLE
FIX: Contact Us form Full Name validation

### DIFF
--- a/src/pages/ContactPage.jsx
+++ b/src/pages/ContactPage.jsx
@@ -67,6 +67,9 @@ const ContactPage = () => {
                                 value={formData.name}
                                 onChange={handleChange}
                                 required
+                                pattern="[a-zA-Z ]+"
+                                oninvalid="this.setCustomValidity('Numbers and Symbols are not allowed')"
+                                oninput="this.setCustomValidity('')"
                             />
                         </div>
                         {/* Phone Number Input */}


### PR DESCRIPTION
## Describe 
The "Full Name" field in the Contact Us form only accepts alphabetical letters (a-z, A-Z). 
## Fixes : #284

## Screenshot 
## Before
![image](https://github.com/user-attachments/assets/fe9d9a7b-b4ee-470a-90f5-cdb2ee732b3f)

# After
![image](https://github.com/user-attachments/assets/5f568b63-55c7-4f52-9984-23b71762f6d7)
