### PR TITLE
FIX : Contact Us form Phone validation

### DIFF
--- a/src/pages/ContactPage.jsx
+++ b/src/pages/ContactPage.jsx
@@ -83,6 +83,9 @@ const ContactPage = () => {
                                 value={formData.phone}
                                 onChange={handleChange}
                                 required
+                                pattern="[0-9]{10}" 
+                                maxlength="10" 
+                                oninput="this.value = this.value.replace(/[^0-9]/g, '');"
                             />
                         </div>
                     </div>


### PR DESCRIPTION
## Describe the bug

The "Phone" field in the Contact Us form only accepts numbers.

## Screenshot

## Before
![image](https://github.com/user-attachments/assets/e4dca228-de71-4d7c-b7d1-b4061b8d2ef2)

## After 
![image](https://github.com/user-attachments/assets/c6ac99db-2efd-4bff-bc63-0135fd33cb5a)
