### PR TITLE
🛠️FIX: Sign up form Full Name validation

### DIFF
--- a/src/pages/SignUpp.jsx
+++ b/src/pages/SignUpp.jsx
@@ -118,15 +118,22 @@ export default function SignUp() {
                     htmlFor="FirstName"
                     className="block text-sm font-medium text-gray-700"
                   >
-                    First Name
+                    Full Name
                   </label>
 
                   <Input
                     placeholder="Enter your full name"
                     {...register("name", {
                       required: true,
+                      pattern: {
+                      value: /^[a-zA-Z ]+$/,
+                      message: 'Numbers and Symbols are not allowed'
+                      }
                     })}
                     className="mt-1 w-full border border-black rounded-md bg-white text-sm text-gray-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-600"
+                    pattern="[a-zA-Z ]+"
+                    onInvalid={(e) => e.target.setCustomValidity('Numbers and Symbols are not allowed')}
+                    onInput={(e) => e.target.setCustomValidity('')}
                   />
                 </div>
 


### PR DESCRIPTION
## Describe 
The "Full Name" field in the Contact Us form only accepts alphabetical letters (a-z, A-Z) and wrong label name is fixed.
## Fixes : #305

## Screenshot 
## Before
![image](https://github.com/user-attachments/assets/ad0fce2f-1386-4b7c-80bb-01726fc4f736)

# After
![image](https://github.com/user-attachments/assets/b29c016f-baa3-4b0a-a8bc-175b0a531dc8)
