### PR TITLE
fix(navbar): ensure navbar remains visible on scroll

### DIFF
--- a/src/componenets/Header/Header.jsx
+++ b/src/componenets/Header/Header.jsx
@@ -129,9 +129,9 @@ export default function Header() {
   const toggleMenu = () => setMenuOpen(!menuOpen);
 
   return (
-    <header className={`header ${isSticky ? "sticky top-0 shadow-xl" : "shadow-lg"} rounded-xl transition-all duration-300`}>
+    <header className={`header ${isSticky ? "sticky top-0 shadow-xl z-50" : "shadow-lg"} rounded-xl transition-all duration-300`}>
 <Container>
-        <nav className="flex justify-between items-center p-4">
+        <nav className="flex justify-between items-center p-4 z-50 sticky top-0 bg-white">
           {/* Logo with Shell icon */}
           <div className=" ml-4 mr-4 flex">
             <Link to="/">


### PR DESCRIPTION
### Summary

This pull request fixes an issue where the navbar would become invisible behind images when scrolling. The following changes were made:

- Set the navbar’s position to `sticky` to keep it visible at the top while scrolling.
- Increased the `z-index` of the navbar to ensure it overlays other content.
- Added a slightly transparent background color to the navbar for better readability against the page content.

These adjustments improve the user experience by making the navigation consistently accessible and enhancing visual appeal.

https://github.com/user-attachments/assets/4c7ff4d4-f4f9-4f1c-8eba-abf210c5ae1c

