### PR TITLE
changed copyright allignment

### DIFF
--- a/src/componenets/Footer/Footer.jsx
+++ b/src/componenets/Footer/Footer.jsx
@@ -8,14 +8,11 @@ function Footer() {
     <footer className="custom-theme w-full bg-gray-300 border-t-1 border-t-black py-10">
       <div className="container mx-auto px-4">
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 text-center md:text-left">
-          {/* Logo and Copyright */}
+          {/* Logo */}
           <section className="p-6 flex flex-col items-center md:items-start">
             <div className="mb-4">
               <Logo width="100px" />
             </div>
-            <p className="text-sm text-gray-600">
-              &copy; 2023 DevUI. All Rights Reserved.
-            </p>
           </section>
 
           {/* Company Links */}
@@ -25,38 +22,10 @@ function Footer() {
             </h3>
             <nav>
               <ul className="space-y-4">
-                <li>
-                  <Link
-                    className="toggle text-base font-medium text-gray-900 hover:text-gray-700"
-                    to="/features"
-                  >
-                    Features
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    className="text-base font-medium text-gray-900 hover:text-gray-700"
-                    to="/pricing"
-                  >
-                    Pricing
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    className="text-base font-medium text-gray-900 hover:text-gray-700"
-                    to="/affiliate-program"
-                  >
-                    Affiliate Program
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    className="text-base font-medium text-gray-900 hover:text-gray-700"
-                    to="/"
-                  >
-                    Press Kit
-                  </Link>
-                </li>
+                <li><Link className="toggle text-base font-medium text-gray-900 hover:text-gray-700" to="/features">Features</Link></li>
+                <li><Link className="text-base font-medium text-gray-900 hover:text-gray-700" to="/pricing">Pricing</Link></li>
+                <li><Link className="text-base font-medium text-gray-900 hover:text-gray-700" to="/affiliate-program">Affiliate Program</Link></li>
+                <li><Link className="text-base font-medium text-gray-900 hover:text-gray-700" to="/">Press Kit</Link></li>
               </ul>
             </nav>
           </section>
@@ -68,55 +37,12 @@ function Footer() {
             </h3>
             <nav>
               <ul className="space-y-4">
-                <li>
-                  <Link
-                    className="text-base font-medium text-gray-900 hover:text-gray-700"
-                    to="/"
-                  >
-                    Account
-                  </Link>
-                </li>
-
-                <li>
-                  <Link
-                    className="text-base font-medium text-gray-900 hover:text-gray-700"
-                    to="/"
-                  >
-                    Help
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    className="text-base font-medium text-gray-900 hover:text-gray-700"
-                    to="/contactus"
-                  >
-                    Contact Us
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    className="text-base font-medium text-gray-900 hover:text-gray-700"
-                    to="/customer-support"
-                  >
-                    Customer Support
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    className="text-base font-medium text-gray-900 hover:text-gray-700"
-                    to="/frequently-asked-questions"
-                  >
-                    FAQ
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    className="text-base font-medium text-gray-900 hover:text-gray-700"
-                    to="/Feedback"
-                  >
-                    Feedback
-                  </Link>
-                </li>
+                <li><Link className="text-base font-medium text-gray-900 hover:text-gray-700" to="/">Account</Link></li>
+                <li><Link className="text-base font-medium text-gray-900 hover:text-gray-700" to="/">Help</Link></li>
+                <li><Link className="text-base font-medium text-gray-900 hover:text-gray-700" to="/contactus">Contact Us</Link></li>
+                <li><Link className="text-base font-medium text-gray-900 hover:text-gray-700" to="/customer-support">Customer Support</Link></li>
+                <li><Link className="text-base font-medium text-gray-900 hover:text-gray-700" to="/frequently-asked-questions">FAQ</Link></li>
+                <li><Link className="text-base font-medium text-gray-900 hover:text-gray-700" to="/Feedback">Feedback</Link></li>
               </ul>
             </nav>
           </section>
@@ -128,30 +54,9 @@ function Footer() {
             </h3>
             <nav>
               <ul className="space-y-4">
-                <li>
-                  <Link
-                    className="text-base font-medium text-gray-900 hover:text-gray-700"
-                    to="/termsandconditions"
-                  >
-                    Terms & Conditions
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    className="text-base font-medium text-gray-900 hover:text-gray-700"
-                    to="/privacypolicy"
-                  >
-                    Privacy Policy
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    className="text-base font-medium text-gray-900 hover:text-gray-700"
-                    to="/licensing"
-                  >
-                    Licensing
-                  </Link>
-                </li>
+                <li><Link className="text-base font-medium text-gray-900 hover:text-gray-700" to="/termsandconditions">Terms & Conditions</Link></li>
+                <li><Link className="text-base font-medium text-gray-900 hover:text-gray-700" to="/privacypolicy">Privacy Policy</Link></li>
+                <li><Link className="text-base font-medium text-gray-900 hover:text-gray-700" to="/licensing">Licensing</Link></li>
               </ul>
             </nav>
           </section>
@@ -162,44 +67,27 @@ function Footer() {
               Follow Us
             </h3>
             <div className="flex space-x-4">
-              <a
-                href="https://facebook.com"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="Facebook"
-                className="text-gray-900 hover:text-gray-700 transition ease-in-out duration-150"
-              >
+              <a href="https://facebook.com" target="_blank" rel="noopener noreferrer" aria-label="Facebook" className="text-gray-900 hover:text-gray-700 transition ease-in-out duration-150">
                 <i className="fab fa-facebook text-2xl"></i>
               </a>
-              <a
-                href="https://twitter.com"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="Twitter"
-                className="text-gray-900 hover:text-gray-700 transition ease-in-out duration-150"
-              >
+              <a href="https://twitter.com" target="_blank" rel="noopener noreferrer" aria-label="Twitter" className="text-gray-900 hover:text-gray-700 transition ease-in-out duration-150">
                 <i className="fab fa-twitter text-2xl"></i>
               </a>
-              <a
-                href="https://instagram.com"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="Instagram"
-                className="text-gray-900 hover:text-gray-700 transition ease-in-out duration-150"
-              >
+              <a href="https://instagram.com" target="_blank" rel="noopener noreferrer" aria-label="Instagram" className="text-gray-900 hover:text-gray-700 transition ease-in-out duration-150">
                 <i className="fab fa-instagram text-2xl"></i>
               </a>
-              <a
-                href="https://linkedin.com"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="LinkedIn"
-                className="text-gray-900 hover:text-gray-700 transition ease-in-out duration-150"
-              >
+              <a href="https://linkedin.com" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn" className="text-gray-900 hover:text-gray-700 transition ease-in-out duration-150">
                 <i className="fab fa-linkedin text-2xl"></i>
               </a>
             </div>
           </section>
+        </div>
+        
+        {/* Copyright Section */}
+        <div className="w-full mt-10 border-t border-black pt-6 text-center">
+          <p className="text-sm text-gray-600">
+            &copy; 2023 DevUI. All Rights Reserved.
+          </p>
         </div>
       </div>
     </footer>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "compilerOptions": {
+     "compilerOptions": {
       "target": "es5", // For broader browser compatibility
       "module": "commonjs", // For Node.js compatibility
       "outDir": "./dist", // Output directory for compiled JavaScript


### PR DESCRIPTION
## Summary
This PR refactors the footer structure to improve the alignment of the copyright text. Previously, the copyright text was nested within the social media section, causing alignment issues and making it slightly off-center. This update moves the copyright text to a separate <div> below the main grid container, ensuring it is centered at the bottom of the footer.

## Changes Made
Moved the copyright <div> outside the main grid container to provide full-width centering.
Added margin (mt-10) above the copyright section for better spacing from the main content.
Ensured text is horizontally centered with text-center class on the copyright text.

## Screenshots
![image](https://github.com/user-attachments/assets/a99c5a08-6dba-473d-bf33-2f66550e292f)

Related Issues
issue: #367 